### PR TITLE
Added board.upload(name, content, on_progress)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "micro-repl",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "micro-repl",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "@xterm/addon-fit": "^0.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "micro-repl",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "micro-repl",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@xterm/addon-fit": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micro-repl",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "main": "./micro-repl.js",
   "module": "./micro-repl.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micro-repl",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "type": "module",
   "main": "./micro-repl.js",
   "module": "./micro-repl.js",

--- a/serial.js
+++ b/serial.js
@@ -27,8 +27,6 @@ const { parse } = JSON;
 const { serial } = navigator;
 const defaultOptions = { hidden: true, raw: false };
 
-const createWriter = writer => chunk => writer.write(chunk);
-
 /**
  * @param {Element} target
  * @returns {Promise<unknown>[]}
@@ -153,7 +151,7 @@ export default function Board({
   const lml = () => accumulator.split(ENTER).at(-2);
 
   const forIt = async () => {
-    while (!accumulator.endsWith(END)) await sleep(10);
+    while (!accumulator.endsWith(END)) await sleep(5);
     const result = lml();
     accumulator = '';
     return result;
@@ -232,26 +230,24 @@ export default function Board({
         };
 
         const writable = new WritableStream({
-          write: createWriter({
-            write(chunk) {
-              if (evaluating) {
-                if (1 < evaluating)
-                  accumulator += decoder.decode(chunk);
-                else if (showEval)
-                  reveal(chunk);
-              }
-              else if (waitForMachine) {
+          write(chunk) {
+            if (evaluating) {
+              if (1 < evaluating)
                 accumulator += decoder.decode(chunk);
-                if (accumulator.endsWith(END) && accumulator.includes(MACHINE)) {
-                  machine.resolve(lml());
-                  accumulator = '';
-                }
-              }
-              else {
+              else if (showEval)
                 reveal(chunk);
+            }
+            else if (waitForMachine) {
+              accumulator += decoder.decode(chunk);
+              if (accumulator.endsWith(END) && accumulator.includes(MACHINE)) {
+                machine.resolve(lml());
+                accumulator = '';
               }
             }
-          })
+            else {
+              reveal(chunk);
+            }
+          }
         });
 
         aborter = new AbortController;
@@ -271,6 +267,10 @@ export default function Board({
                   pastMode = true;
                 else if (code === 'KeyD') {
                   event.preventDefault();
+                  if (evaluating) {
+                    evaluating = 0;
+                    accumulator = '';
+                  }
                   board.reset();
                   return false;
                 }
@@ -279,14 +279,19 @@ export default function Board({
             // prevent errors with huge content passed in paste mode
             else if (pastMode && composed && ctrlKey && shiftKey && code === 'KeyV') {
               event.preventDefault();
-              navigator.clipboard.readText().then(code => exec(code, writer));
+              navigator.clipboard.readText().then(async code => {
+                while (evaluating) await sleep(10);
+                await exec(code, writer);
+              });
               return false;
             }
           }
           return true;
         });
 
-        terminal.onData(createWriter(writer));
+        terminal.onData(chunk => {
+          if (!evaluating) writer.write(chunk);
+        });
 
         const fitAddon = new FitAddon;
         terminal.loadAddon(fitAddon);
@@ -414,6 +419,49 @@ export default function Board({
         showEval = false;
       }
       else onerror(reason('paste', evaluating));
+    },
+
+    /**
+     * Upload a file to the board showing some progress while doing that.
+     * @param {string} path the name of the file to upload.
+     * @param {string | File | Blob} content the file content as string or blob or as file.
+     * @param {(current, total) => void} onprogress an optional callback to receive current uploaded and total.
+     */
+    upload: async (path, content, onprogress = noop) => {
+      if (port && !evaluating) {
+        const update = i => {
+          const value = i === length ? 100 : (i * 100 / length).toFixed(2);
+          terminal.write(`\x1b[M... uploading ${path} ${value}% `);
+        };
+        const view = typeof content === 'string' ?
+          new TextEncoder().encode(content) :
+          new Uint8Array(await content.arrayBuffer())
+        ;
+        const { stringify } = JSON;
+        const { floor } = Math;
+        const { length } = view;
+        let increment = 32, i = 0;
+        evaluating = 2;
+        await writer.write(`f=open(${stringify(path)},"wb")\r`);
+        await sleep(10);
+        while (i < length) {
+          onprogress(i, length);
+          update(i);
+          const chunks = stringify([...view.slice(i, i + increment)]);
+          await writer.write(`f.write("".join([chr(c) for c in ${chunks}]))\r`);
+          while (!/^\d+$/.test(lml())) await sleep(5);
+          accumulator = '';
+          i += increment;
+        }
+        onprogress(length, length);
+        update(length);
+        await writer.write(`f.close()\r`);
+        await sleep(10);
+        evaluating = 0;
+        accumulator = '';
+        // terminal.write('\x1b[M\x1b[A');
+      }
+      else onerror(reason('upload', evaluating));
     },
 
     /**

--- a/serial.js
+++ b/serial.js
@@ -438,7 +438,6 @@ export default function Board({
           new Uint8Array(await content.arrayBuffer())
         ;
         const { stringify } = JSON;
-        const { floor } = Math;
         const { length } = view;
         let increment = 32, i = 0;
         evaluating = 2;


### PR DESCRIPTION
This MR does a few things to improve the `upload` story from PC to board:

  * it offers a `bord.upload(path, content, on_progress)` API that
    * save the file into path
    * understand content either as `string` or as a file (or Blob)
    * notify the optional `on_progress` callback with current size sent and total size to send
    * put the terminal in non-responsive mode until it finishes uploading
    * show in terminal to the same line the current state of the upload
  * this MR also takes an opportunity to improve typing on terminal while evaluating, as that can disturb indeed the outcome of a program so that it's disabled while the terminal is still evaluating

```js
// example: create a test.txt with hello world repeated 10 times
await board.upload('test.txt', 'hello world\r\n'.repeat(10));
```